### PR TITLE
Some bug fixes

### DIFF
--- a/include/collections.h
+++ b/include/collections.h
@@ -30,7 +30,7 @@
 #ifdef LIBCOLLECTIONS_COMPILE
 # define MAJOR_VERSION          0
 # define MINOR_VERSION          0
-# define BUILD                  42
+# define BUILD                  43
 #endif
 
 #ifdef __cplusplus

--- a/src/adt/hashtable.c
+++ b/src/adt/hashtable.c
@@ -321,9 +321,13 @@ static unsigned short int hash16(unsigned char *k, unsigned int length,
 
 static int hashkey(const char *key, unsigned int hashtable_size)
 {
-    unsigned int old_hash = PRIME_NUMBER, rnd;
+    unsigned int old_hash = PRIME_NUMBER, rnd, length = KEY_SIZE;
+    size_t l_key = strlen(key);
 
-    rnd = hash16((unsigned char *)key, KEY_SIZE, old_hash);
+    if (l_key > KEY_SIZE)
+        length = l_key;
+
+    rnd = hash16((unsigned char *)key, length, old_hash);
 
     return (rnd % hashtable_size);
 }

--- a/src/json.c
+++ b/src/json.c
@@ -380,11 +380,16 @@ static const char *parse_number(cl_json_s *j, const char *num)
 
     num = get_number(num, &n);
     num = get_float_part(num, &n, &scale, &type);
-    num = get_exponent_notation(num, &sign_subscale, &subscale);
 
-    n = sign * n * pow(10.0, (scale + subscale * sign_subscale));
+    if (type == CL_JSON_NUMBER_FLOAT) {
+        num = get_exponent_notation(num, &sign_subscale, &subscale);
+        n = sign * n * pow(10.0, (scale + subscale * sign_subscale));
+        j->value = cl_string_create("%f", n);
+    } else {
+        n = sign * n;
+        j->value = cl_string_create("%d", (int)n);
+    }
 
-    j->value = cl_string_create("%f", n);
     j->type = type;
 
     return num;

--- a/src/string.c
+++ b/src/string.c
@@ -844,7 +844,7 @@ __PUB_API__ int cl_string_to_int(const cl_string_t *string)
         return -1;
     }
 
-    if (endptr == p->str) {
+    if ((endptr == p->str) || (*endptr != '\0')) {
         cl_string_unref(p);
         cset_errno(CL_NOT_A_NUMBER);
         return -1;


### PR DESCRIPTION
- Fixing the conversion from a cl_string_t to a int value when the
  string has non digits.

- Fixing the parse of a JSON number, when the object is an int number,
  to keep the object value with the correct value, in this case,
  without any decimal point.

- Fixing the hashtable key size used to get the element index.